### PR TITLE
look for libraries in /lib/obs-plugins

### DIFF
--- a/src/obs-kinect/KinectPlugin.cpp
+++ b/src/obs-kinect/KinectPlugin.cpp
@@ -45,7 +45,7 @@ bool KinectPlugin::Open(const std::string& path)
 #ifdef _WIN32
 	ObsLibPtr lib(os_dlopen(path.c_str()));
 #else
-	ObsLibPtr lib(os_dlopen(("./obs-plugins/" + path).c_str()));
+	ObsLibPtr lib(os_dlopen(("/app/plugins/lib/obs-plugins/" + path).c_str()));
 #endif
 
 	if (!lib)

--- a/src/obs-kinect/KinectPlugin.cpp
+++ b/src/obs-kinect/KinectPlugin.cpp
@@ -42,8 +42,11 @@ bool KinectPlugin::IsOpen() const
 
 bool KinectPlugin::Open(const std::string& path)
 {
+#ifdef _WIN32
 	ObsLibPtr lib(os_dlopen(path.c_str()));
-	ObsLibPtr lib(os_dlopen(("/app/plugins/lib/obs-plugins/" + path).c_str()));
+#else
+	ObsLibPtr lib(os_dlopen(("obs-plugins/" + path).c_str()));
+#endif
 
 	if (!lib)
 		return false;

--- a/src/obs-kinect/KinectPlugin.cpp
+++ b/src/obs-kinect/KinectPlugin.cpp
@@ -42,12 +42,17 @@ bool KinectPlugin::IsOpen() const
 
 bool KinectPlugin::Open(const std::string& path)
 {
-#ifdef _WIN32
-	ObsLibPtr lib(os_dlopen(path.c_str()));
-#else
-	ObsLibPtr lib(os_dlopen(("obs-plugins/" + path).c_str()));
+	void* libPtr = os_dlopen(path.c_str());
+#ifndef _WIN32
+	if (!libPtr)
+	{
+		libPtr = os_dlopen(("./" + path).c_str());
+		if (!libPtr)
+			libPtr = os_dlopen(("obs-plugins/" + path).c_str());
+	}
 #endif
 
+	ObsLibPtr lib(libPtr);
 	if (!lib)
 		return false;
 

--- a/src/obs-kinect/KinectPlugin.cpp
+++ b/src/obs-kinect/KinectPlugin.cpp
@@ -42,11 +42,8 @@ bool KinectPlugin::IsOpen() const
 
 bool KinectPlugin::Open(const std::string& path)
 {
-#ifdef _WIN32
 	ObsLibPtr lib(os_dlopen(path.c_str()));
-#else
 	ObsLibPtr lib(os_dlopen(("/app/plugins/lib/obs-plugins/" + path).c_str()));
-#endif
 
 	if (!lib)
 		return false;

--- a/src/obs-kinect/KinectPlugin.cpp
+++ b/src/obs-kinect/KinectPlugin.cpp
@@ -45,7 +45,7 @@ bool KinectPlugin::Open(const std::string& path)
 #ifdef _WIN32
 	ObsLibPtr lib(os_dlopen(path.c_str()));
 #else
-	ObsLibPtr lib(os_dlopen(("/app/plugins/lib/obs-plugins/" + path).c_str()));
+	ObsLibPtr lib(os_dlopen(("./obs-plugins/" + path).c_str()));
 #endif
 
 	if (!lib)

--- a/src/obs-kinect/KinectPlugin.cpp
+++ b/src/obs-kinect/KinectPlugin.cpp
@@ -45,7 +45,7 @@ bool KinectPlugin::Open(const std::string& path)
 #ifdef _WIN32
 	ObsLibPtr lib(os_dlopen(path.c_str()));
 #else
-	ObsLibPtr lib(os_dlopen(("/app/plugins/lib/obs-plugins" + path).c_str()));
+	ObsLibPtr lib(os_dlopen(("/app/plugins/lib/obs-plugins/" + path).c_str()));
 #endif
 
 	if (!lib)

--- a/src/obs-kinect/KinectPlugin.cpp
+++ b/src/obs-kinect/KinectPlugin.cpp
@@ -42,7 +42,11 @@ bool KinectPlugin::IsOpen() const
 
 bool KinectPlugin::Open(const std::string& path)
 {
+#ifdef _WIN32
 	ObsLibPtr lib(os_dlopen(path.c_str()));
+#else
+	ObsLibPtr lib(os_dlopen(("/app/plugins/lib/obs-plugins" + path).c_str()));
+#endif
 
 	if (!lib)
 		return false;

--- a/src/obs-kinect/KinectPlugin.cpp
+++ b/src/obs-kinect/KinectPlugin.cpp
@@ -48,7 +48,7 @@ bool KinectPlugin::Open(const std::string& path)
 	{
 		libPtr = os_dlopen(("./" + path).c_str());
 		if (!libPtr)
-			libPtr = os_dlopen(("obs-plugins/" + path).c_str());
+			libPtr = os_dlopen(("/app/plugins/lib/obs-plugins/" + path).c_str());
 	}
 #endif
 


### PR DESCRIPTION
This makes it find everything when in a Flatpak extension. I know this doesn't look right (I barely know c++), but I was hoping for os_dlopen to look for both the regular path and this one so that it doesn't affect regular non-flatpak installations. What do you think? Can both be added? I only reverted d7ea9d0 and changed the path.

Btw, kinect v2 fully works now! :D
`flatpak install https://dl.flathub.org/build-repo/128310/com.obsproject.Studio.Plugin.obs-kinect.flatpakref`